### PR TITLE
Prompt improvements

### DIFF
--- a/CommandHandling/DotCommandHandler.cs
+++ b/CommandHandling/DotCommandHandler.cs
@@ -10,7 +10,7 @@ public class DotCommandHandler<TConnection> where TConnection : DbConnection
 {
     private readonly RootCommandHandler _rootCommandHandler;
     private readonly TConnection _connection;
-    private readonly IDictionary<string, Func<string[], CancellationToken, Task>> _dotCommands;
+    private readonly IDictionary<string, Func<ImmutableArray<string>, CancellationToken, Task>> _dotCommands;
     private readonly IDbMetadataProvider<TConnection> _metadataProvider;
 
     public DotCommandHandler(RootCommandHandler rootCommandHandler, TConnection connection, IDbMetadataProvider<TConnection> metadataProvider)
@@ -21,14 +21,14 @@ public class DotCommandHandler<TConnection> where TConnection : DbConnection
         _metadataProvider = metadataProvider;
     }
 
-    private IDictionary<string, Func<string[], CancellationToken, Task>> BuildDotCommands() => ImmutableDictionary.CreateRange(
-        new KeyValuePair<string, Func<string[], CancellationToken, Task>>[] {
-            KeyValuePair.Create<string, Func<string[], CancellationToken, Task>>(".exit", Exit),
-            KeyValuePair.Create<string, Func<string[], CancellationToken, Task>>(".listTables", ListTables),
-            KeyValuePair.Create<string, Func<string[], CancellationToken, Task>>(".listColumns", ListColumns),
-            KeyValuePair.Create<string, Func<string[], CancellationToken, Task>>(".listOutputFormats", ListOutputFormats),
-            KeyValuePair.Create<string, Func<string[], CancellationToken, Task>>(".getOutputFormat", GetOutputFormat),
-            KeyValuePair.Create<string, Func<string[], CancellationToken, Task>>(".setOutputFormat", SetOutputFormat),
+    private IDictionary<string, Func<ImmutableArray<string>, CancellationToken, Task>> BuildDotCommands() => ImmutableDictionary.CreateRange(
+        new KeyValuePair<string, Func<ImmutableArray<string>, CancellationToken, Task>>[] {
+            KeyValuePair.Create<string, Func<ImmutableArray<string>, CancellationToken, Task>>(".exit", Exit),
+            KeyValuePair.Create<string, Func<ImmutableArray<string>, CancellationToken, Task>>(".listTables", ListTables),
+            KeyValuePair.Create<string, Func<ImmutableArray<string>, CancellationToken, Task>>(".listColumns", ListColumns),
+            KeyValuePair.Create<string, Func<ImmutableArray<string>, CancellationToken, Task>>(".listOutputFormats", ListOutputFormats),
+            KeyValuePair.Create<string, Func<ImmutableArray<string>, CancellationToken, Task>>(".getOutputFormat", GetOutputFormat),
+            KeyValuePair.Create<string, Func<ImmutableArray<string>, CancellationToken, Task>>(".setOutputFormat", SetOutputFormat),
         }
     );
 
@@ -39,15 +39,15 @@ public class DotCommandHandler<TConnection> where TConnection : DbConnection
         {
             throw new ArgumentException($"No command found matching {tokens.First()}");
         }
-        await _dotCommands[tokens.First()](tokens.Skip(1).ToArray(), cancellationToken);
+        await _dotCommands[tokens.First()](tokens.Skip(1).ToImmutableArray(), cancellationToken);
     }
 
-    public async Task Exit(string[] args, CancellationToken cancellationToken)
+    public async Task Exit(ImmutableArray<string> args, CancellationToken cancellationToken)
     {
         _rootCommandHandler.Terminate();
     }
 
-    public async Task ListTables(string[] args, CancellationToken cancellationToken)
+    public async Task ListTables(ImmutableArray<string> args, CancellationToken cancellationToken)
     {
         var dbTables = await _metadataProvider.GetTables(_connection, cancellationToken);
         var table = new Table();
@@ -59,7 +59,7 @@ public class DotCommandHandler<TConnection> where TConnection : DbConnection
         AnsiConsole.Write(table);
     }
 
-    public async Task ListColumns(string[] args, CancellationToken cancellationToken)
+    public async Task ListColumns(ImmutableArray<string> args, CancellationToken cancellationToken)
     {
         if (args.Length == 0)
         {
@@ -76,7 +76,7 @@ public class DotCommandHandler<TConnection> where TConnection : DbConnection
         AnsiConsole.Write(table);
     }
 
-    public async Task ListOutputFormats(string[] args, CancellationToken cancellationToken)
+    public async Task ListOutputFormats(ImmutableArray<string> args, CancellationToken cancellationToken)
     {
         var table = new Table();
         table.AddColumns($"[bold blue]Format[/]", "[bold blue]Description[/]");
@@ -87,7 +87,7 @@ public class DotCommandHandler<TConnection> where TConnection : DbConnection
         AnsiConsole.Write(table);
     }
 
-    public async Task GetOutputFormat(string[] args, CancellationToken cancellationToken)
+    public async Task GetOutputFormat(ImmutableArray<string> args, CancellationToken cancellationToken)
     {
         var table = new Table();
         table.AddColumns($"[bold blue]Format[/]", "[bold blue]Description[/]");
@@ -95,7 +95,7 @@ public class DotCommandHandler<TConnection> where TConnection : DbConnection
         AnsiConsole.Write(table);
     }
 
-    public async Task SetOutputFormat(string[] args, CancellationToken cancellationToken)
+    public async Task SetOutputFormat(ImmutableArray<string> args, CancellationToken cancellationToken)
     {
         _rootCommandHandler.SetOutputFormatByName(args[0]);
     }

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.CommandLine;
 
 namespace QueryTerminal;
@@ -7,7 +8,7 @@ public static class Extensions
     public static void SetHandler<T1,T2,T3>(this Command command, Func<CancellationToken,IServiceProvider,T1?,T2?,T3?,Task> handler, IServiceProvider serviceProvider, params Option[] options)
     {
         command.SetHandler(async context => {
-            object?[] optionValues = options.Select(o => context.ParseResult.GetValueForOption(o)).ToArray();
+            ImmutableArray<object?> optionValues = options.Select(o => context.ParseResult.GetValueForOption(o)).ToImmutableArray();
             CancellationToken cancellationToken = context.GetCancellationToken();
             await handler(cancellationToken, serviceProvider, (T1?)optionValues[0], (T2?)optionValues[1], (T3?)optionValues[2]);
         });
@@ -16,7 +17,7 @@ public static class Extensions
     public static void SetHandler<T1,T2,T3,T4>(this Command command, Func<CancellationToken,IServiceProvider,T1?,T2?,T3?,T4?,Task> handler, IServiceProvider serviceProvider, params Option[] options)
     {
         command.SetHandler(async context => {
-            object?[] optionValues = options.Select(o => context.ParseResult.GetValueForOption(o)).ToArray();
+            ImmutableArray<object?> optionValues = options.Select(o => context.ParseResult.GetValueForOption(o)).ToImmutableArray();
             CancellationToken cancellationToken = context.GetCancellationToken();
             await handler(cancellationToken, serviceProvider, (T1?)optionValues[0], (T2?)optionValues[1], (T3?)optionValues[2], (T4?)optionValues[3]);
         });

--- a/OutputFormatting/DBNullJsonConverter.cs
+++ b/OutputFormatting/DBNullJsonConverter.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace QueryTerminal.OutputFormatting;
 
-class DBNullJsonConverter : JsonConverter<DBNull>
+internal class DBNullJsonConverter : JsonConverter<DBNull>
 {
     public override DBNull Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {

--- a/Program.cs
+++ b/Program.cs
@@ -2,10 +2,10 @@
 using Microsoft.Data.SqlClient;
 using QueryTerminal.CommandHandling;
 using Microsoft.Extensions.DependencyInjection;
-using QueryTerminal.OutputFormatting;
 using Spectre.Console;
 using Microsoft.Data.Sqlite;
 using QueryTerminal.Data;
+using QueryTerminal.Prompting;
 
 namespace QueryTerminal;
 
@@ -30,10 +30,7 @@ class Program
         services.AddTransient<IDbMetadataProvider<SqlConnection>, SqlMetadataProvider>();
         services.AddTransient<IDbMetadataProvider<SqliteConnection>, SqliteMetadataProvider>();
 
-        // foreach (var outputFormat in OutputFormat.List())
-        // {
-        //     services.AddKeyedTransient<IOutputFormatter>(outputFormat.Name, outputFormat.ImplementationFactory);
-        // }
+        services.AddTransient<QueryTerminalPrompt>();
 
         var serviceProvider = services.BuildServiceProvider();
 

--- a/Prompting/QueryTerminalPrompt.cs
+++ b/Prompting/QueryTerminalPrompt.cs
@@ -1,0 +1,35 @@
+using PrettyPrompt;
+using PrettyPrompt.Highlighting;
+
+namespace QueryTerminal.Prompting;
+
+public class QueryTerminalPrompt : IAsyncDisposable
+{
+    private readonly Prompt _delegatePrompt;
+
+    public QueryTerminalPrompt()
+    {
+        var persistentHistoryFilepath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".queryterm.hist");
+        _delegatePrompt = new Prompt(
+            persistentHistoryFilepath: persistentHistoryFilepath,
+            callbacks: new QueryTerminalPromptCallbacks(),
+            configuration: new PromptConfiguration(
+                prompt: "> ",
+                // completionItemDescriptionPaneBackground: AnsiColor.Rgb(30, 30, 30),
+                // selectedCompletionItemBackground: AnsiColor.Rgb(30, 30, 30),
+                selectedTextBackground: AnsiColor.Rgb(20, 61, 102)
+            )
+        );
+    }
+
+    public async Task<PromptResult> ReadLineAsync()
+    {
+        return await _delegatePrompt.ReadLineAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _delegatePrompt.DisposeAsync();
+    }
+}
+

--- a/Prompting/QueryTerminalPromptCallbacks.cs
+++ b/Prompting/QueryTerminalPromptCallbacks.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using PrettyPrompt;
+using PrettyPrompt.Completion;
+using PrettyPrompt.Documents;
+using PrettyPrompt.Highlighting;
+
+namespace QueryTerminal.Prompting;
+
+internal class QueryTerminalPromptCallbacks : PromptCallbacks
+{
+    // TODO: Reverse search
+    // protected override IEnumerable<(KeyPressPattern Pattern, KeyPressCallbackAsync Callback)> GetKeyPressCallbacks()
+    // {
+    //     // registers functions to be called when the user presses a key. The text
+    //     // currently typed into the prompt, along with the caret position within
+    //     // that text are provided as callback parameters.
+    //     yield return (new(ConsoleModifiers.Control, ConsoleKey.R), ReverseCommandSearch);
+    // }
+
+    // TODO: implement this stub
+    protected override async Task<IReadOnlyList<CompletionItem>> GetCompletionItemsAsync(string text, int caret, TextSpan spanToBeReplaced, CancellationToken cancellationToken)
+    {
+        return Enumerable.Empty<CompletionItem>().ToImmutableList();
+    }
+
+    protected override async Task<IReadOnlyCollection<FormatSpan>> HighlightCallbackAsync(string text, CancellationToken cancellationToken)
+    {
+        return EnumerateFormatSpans(text).ToImmutableList();
+    }
+
+    private static IEnumerable<FormatSpan> EnumerateFormatSpans(string text)
+    {
+        foreach (var textToFormat in Keywords)
+        {
+            int startIndex;
+            int offset = 0;
+            while ((startIndex = text.AsSpan(offset).IndexOf(textToFormat, StringComparison.InvariantCultureIgnoreCase)) != -1)
+            {
+                yield return new FormatSpan(offset + startIndex, textToFormat.Length, AnsiColor.Blue);
+                offset += startIndex + textToFormat.Length;
+            }
+        }
+    }
+
+    private static readonly string[] Keywords = new[]
+    {
+        "SELECT",
+        "FROM",
+        "AS",
+        "GROUP BY",
+        "ORDER BY",
+        "DESC",
+        "ASC",
+        "IN",
+        "AND",
+        "OR",
+        "NOT",
+        "LIKE",
+        "(",
+        ")",
+        "=",
+    };
+
+}


### PR DESCRIPTION
The most basic implementation of using PrettyPrompt, providing the following
- Caret movable within commands
- Command History
- Basic, static syntax highlighting

Does not provide (i.e. these are still TODOs)
- Completion
- Dynamic syntax highlighting
- Reverse command search

Also includes other misc cleanup changes that I didn't feel like deferring, but aren't directly tied to the new features (cd41f38 and 27d8718)